### PR TITLE
bugfix: variadic function type checking

### DIFF
--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -1,6 +1,10 @@
 package a
 
+import "fmt"
+
 type A[T any] = any
+
+func p[T any](_ ...A[T]) {}
 
 func f() {
 	var _ any = A[any](nil)                                             // OK
@@ -13,4 +17,9 @@ func f() {
 	*new(A[string]), *new(bool) = map[int]A[bool]{}[0]                  // want `type annotations are not assignable: a\.A\[bool\] to a\.A\[string\]`
 	*new(A[string]), *new(bool) = any(nil).(A[bool])                    // want `type annotations are not assignable: a\.A\[bool\] to a\.A\[string\]`
 	var _, _ A[string] = func() (_ A[string], _ A[bool]) { return }()   // want `type annotations are not assignable: a\.A\[bool\] to a\.A\[string\]`
+	fmt.Printf("I'm %s", "Gopher")                                      // OK
+	p[string]()                                                         // OK
+	p[any](A[bool](nil))                                                // OK
+	p[string](A[bool](nil))                                             // want `type annotations are not assignable: a\.A\[bool\] to a\.A\[string\]`
+	p[string](A[string](nil), A[bool](nil))                             // want `type annotations are not assignable: a\.A\[bool\] to a\.A\[string\]`
 }


### PR DESCRIPTION
I've fixed a bug in the type validation logic for calls to variadic functions.

### The Problem

Previously, the analyzer was comparing the type of an argument passed to a variadic parameter against the parameter's **slice type**, instead of its **element type**.

For example, given a function `func p(args ...any) {}`, a call like `p("string message")` would incorrectly produce the following error:
> types are not assignable: string to []any

This is incorrect because the checker was attempting to assign the argument's type (`string`) to the slice type (`[]any`). The correct behavior is to validate if `string` is assignable to the element type `any`.

### The Solution

This patch corrects the logic to ensure the analyzer properly resolves the element type of a variadic parameter. It now correctly validates that each provided argument is assignable to that element type.

As a result, the call mentioned above is now correctly validated without any errors.